### PR TITLE
RFC compliance and fixes for issue #137

### DIFF
--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -523,7 +523,7 @@ class Rule
         }
 
         // DTEND
-        if ($this->endDate instanceof \DateTime) {
+        if ($this->endDate instanceof \DateTimeInterface) {
             if ($timezoneType === self::TZ_FIXED) {
                 $d = $this->getEndDate();
                 $tzid = $d->getTimezone()->getName();

--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -384,8 +384,6 @@ class Rule
             if (isset($parts['TZID'])) {
                 //DTSTART is datetime in TZID timezone
                 $date = new \DateTime($parts['DTSTART'], $timezone);
-                var_dump($date);
-                var_dump($date->format('l, F j, Y - h:i A e'));
             } else {
                 //DTSTART is UTC, convert to timezone coming from constructor/startDate/default
                 $date = new \DateTime($parts['DTSTART']);

--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -520,7 +520,7 @@ class Rule
                 $date = $d->format($format);
                 $parts[] = "DTSTART;TZID=$tzid:$date";
             } else {
-                $parts[] = 'DTSTART='.$this->getStartDate()->format($format);
+                $parts[] = 'DTSTART:'.$this->getStartDate()->format($format);
             }
         }
 

--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -293,9 +293,7 @@ class Rule
         //4) FREQ=DAILY;DTSTART;TZID=UTC:20200607T120200;INTERVAL=1
         //5) FREQ=DAILY;DTSTART:20200607T120200;INTERVAL=1
 
-
-        //SOLUTION
-        //split by ';':
+        //SOLUTION: split by ';':
         //1) [DTSTART:20200607T120200]
         //2) [DTSTART, TZID=UTC:20200607T120200]
         //3) [RRULE:FREQ=DAILY, INTERVAL=1]
@@ -386,6 +384,8 @@ class Rule
             if (isset($parts['TZID'])) {
                 //DTSTART is datetime in TZID timezone
                 $date = new \DateTime($parts['DTSTART'], $timezone);
+                var_dump($date);
+                var_dump($date->format('l, F j, Y - h:i A e'));
             } else {
                 //DTSTART is UTC, convert to timezone coming from constructor/startDate/default
                 $date = new \DateTime($parts['DTSTART']);

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -43,6 +43,8 @@ class RuleTest extends \PHPUnit_Framework_TestCase
 
         $startDate = $rule->getStartDate();
         $this->assertSame('2020-06-07 12:02:00', $startDate->format('Y-m-d H:i:s'));
+
+
         $this->assertSame('EUROPE/LONDON', $startDate->getTimezone()->getName());
     }
 

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -304,7 +304,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         $defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('America/Chicago');
 
-        $string = 'FREQ=MONTHLY;DTSTART=20140222T073000';
+        $string = 'FREQ=MONTHLY;DTSTART:20140222T073000';
 
         $this->rule->setTimezone('America/Los_Angeles');
         $this->rule->loadFromString($string);
@@ -385,7 +385,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetStringWithDtstart()
     {
-        $string = 'FREQ=MONTHLY;DTSTART=20140210T163045;INTERVAL=1;WKST=MO';
+        $string = 'FREQ=MONTHLY;DTSTART:20140210T163045;INTERVAL=1;WKST=MO';
 
         $this->rule->loadFromString($string);
 
@@ -446,7 +446,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FREQ=MONTHLY;COUNT=2', $this->rule->getString());
 
         $this->rule->setStartDate(new \DateTime('2015-12-10'), true);
-        $this->assertEquals('FREQ=MONTHLY;COUNT=2;DTSTART=20151210T000000', $this->rule->getString());
+        $this->assertEquals('FREQ=MONTHLY;COUNT=2;DTSTART:20151210T000000', $this->rule->getString());
 
         $this->rule->setStartDate(new \DateTime('2015-12-10'), false);
         $this->assertEquals('FREQ=MONTHLY;COUNT=2', $this->rule->getString());

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -17,6 +17,28 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         $this->rule = new Rule;
     }
 
+    public function testCanConvertRruleBackAndForthAndGetSameResult()
+    {
+        $rule = new Rule("DTSTART:20200607T120200\r\nRRULE:FREQ=DAILY;INTERVAL=1");
+        $rruleOne = $rule->getString(Rule::TZ_FIXED);
+
+        $rule2 = new Rule($rruleOne);
+        $rruleTwo = $rule2->getString(Rule::TZ_FIXED);
+
+        $this->assertSame($rruleOne, $rruleTwo);
+    }
+
+    public function testCanCreateRuleFromStringHavingTzid()
+    {
+        $rule = new Rule("DTSTART;TZID=Europe/London:20200607T120200\r\nRRULE:FREQ=DAILY;INTERVAL=1");
+
+        $this->assertEquals('EUROPE/LONDON', $rule->getTimezone());
+
+        $startDate = $rule->getStartDate();
+        $this->assertSame('2020-06-07 12:02:00', $startDate->format('Y-m-d H:i:s'));
+        $this->assertSame('EUROPE/LONDON', $startDate->getTimezone()->getName());
+    }
+
     public function testConstructAcceptableStartDate()
     {
         $this->rule = new Rule(null, null);

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -19,13 +19,20 @@ class RuleTest extends \PHPUnit_Framework_TestCase
 
     public function testCanConvertRruleBackAndForthAndGetSameResult()
     {
-        $rule = new Rule("DTSTART:20200607T120200\r\nRRULE:FREQ=DAILY;INTERVAL=1");
-        $rruleOne = $rule->getString(Rule::TZ_FIXED);
+        $rrules = [
+            "DTSTART:20200607T120200\r\nRRULE:FREQ=DAILY;INTERVAL=1",
+            "DTSTART;TZID=Europe/London:20200607T120200\r\nRRULE:FREQ=DAILY;INTERVAL=1"
+        ];
 
-        $rule2 = new Rule($rruleOne);
-        $rruleTwo = $rule2->getString(Rule::TZ_FIXED);
+        foreach ($rrules as $rrule) {
+            $rule = new Rule($rrule);
+            $rruleOne = $rule->getString(Rule::TZ_FIXED);
 
-        $this->assertSame($rruleOne, $rruleTwo);
+            $rule2 = new Rule($rruleOne);
+            $rruleTwo = $rule2->getString(Rule::TZ_FIXED);
+
+            $this->assertSame($rruleOne, $rruleTwo);
+        }
     }
 
     public function testCanCreateRuleFromStringHavingTzid()

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -6,6 +6,7 @@ use Recurr\DateExclusion;
 use Recurr\DateInclusion;
 use Recurr\Frequency;
 use Recurr\Rule;
+use DateTimeImmutable;
 
 class RuleTest extends \PHPUnit_Framework_TestCase
 {
@@ -46,6 +47,18 @@ class RuleTest extends \PHPUnit_Framework_TestCase
 
 
         $this->assertSame('EUROPE/LONDON', $startDate->getTimezone()->getName());
+    }
+
+    public function testCanCreateRruleIfEndIsPassedAsDateTimeImmutable()
+    {
+        $begin = new DateTimeImmutable('2012-08-01');
+        $end = new DateTimeImmutable('2012-08-31');
+        $xmas = new DateTimeImmutable('2012-12-25');
+
+        $rule = new Rule('FREQ=WEEKLY;COUNT=5', $begin, $end);
+        $string = $rule->getString();
+
+        $this->assertEquals('FREQ=WEEKLY;COUNT=5;DTEND=20120831T000000', $string);
     }
 
     public function testConstructAcceptableStartDate()


### PR DESCRIPTION
Bug 1: recurr does not parse rrule string correctly if the string has TZID. At the same time when converting Rule to string recurr is able to output TZID. 
Bug 2: When converting Rule to string, recurr outputs 'DTSTART=', which RFC 5545 doesnt allow, and which recurr is not able to correctly parse

1) Test Recurr is able to parse the string created by itself
2) Fix parsing for the test to pass

Bug 3: If endDate is passed as DateTimeImmutable it is not applied to the produced rrule string because the check is `instanceOf DateTime`. Check for `DateTimeInterface`

DTSTART, DTEND and TZID from rrule string take precedence over constructor parameters